### PR TITLE
Removed rmagick depreciation warning

### DIFF
--- a/lib/fictionArt.rb
+++ b/lib/fictionArt.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require 'rmagick'
 require 'uri'
 require 'open-uri'
 require 'rainbow'

--- a/lib/fictionArt.rb
+++ b/lib/fictionArt.rb
@@ -12,8 +12,8 @@ class FictionArt
   # Constructor function of FictionArt class
   def initialize(text = "nothing")
   	
-  	@image_chars ||= ' .~:+=o*x^%#@'.chars.to_a
-	check = Dir.glob("#{__dir__}/../images/#{text}.jpg")
+    @image_chars ||= ' .~:+=o*x^%#@'.chars.to_a
+    check = Dir.glob("#{__dir__}/../images/#{text}.jpg")
 
     if check.length == 0
 	  if text == "nothing"
@@ -25,7 +25,7 @@ class FictionArt
 	  	@status = false   # for tests
 	  	puts 
 	  	check_possible(text)
-      end
+          end
     else
       open(check[0]) { |file| @data = file.read }
       @status = true   # for tests
@@ -81,7 +81,7 @@ class FictionArt
 
 	  output << border
 	  return output
-	end
+    end
   end
 
 


### PR DESCRIPTION
**WARNING** Running this resulted in a warning, 

> "[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead". 

**MODIFICATION**
This is a bit messy when redirecting to file, so I've simply fixed the deprecation and am sharing it back. As a poke-super-herofan, thank you for a cool little tool. I've also fixed a second issue about some block alignment warnings.